### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/wlanpi_webui/templates/partials/network.html
+++ b/wlanpi_webui/templates/partials/network.html
@@ -1,26 +1,31 @@
 <script>
   function copyCardToClipboard(card) {
-    if (window.clipboardData && window.clipboardData.setData) {
-      // Internet Explorer-specific code path to prevent textarea being shown while dialog is visible.
-      return window.clipboardData.setData("Text", text);
+    const text = document.getElementById(card).innerText;
+
+    if (navigator.clipboard?.writeText && window.isSecureContext) {
+      navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
+      return true;
     }
-    else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
-      var input = document.createElement("textarea");
-      // we're copying from a <p> tag in this instance
-      input.textContent = document.getElementById(card).innerText;
-      input.style.position = "fixed";
-      document.body.appendChild(input);
-      input.select();
-      try {
-        document.execCommand("copy");
-      }
-      catch (ex) {
-        console.warn("Copy to clipboard failed.", ex);
-        return false;
-      }
-      finally {
-        document.body.removeChild(input);
-      }
+
+    return fallbackCopy(text);
+  }
+
+  function fallbackCopy(text) {
+    if (!document.queryCommandSupported?.("copy")) return false;
+
+    const input = document.createElement("textarea");
+    input.textContent = text;
+    input.style.position = "fixed";
+    document.body.appendChild(input);
+    input.select();
+    try {
+      document.execCommand("copy");
+      return true;
+    } catch (ex) {
+      console.warn("Copy to clipboard failed.", ex);
+      return false;
+    } finally {
+      document.body.removeChild(input);
     }
   }
 </script>

--- a/wlanpi_webui/templates/partials/network.html
+++ b/wlanpi_webui/templates/partials/network.html
@@ -7,7 +7,7 @@
     else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
       var input = document.createElement("textarea");
       // we're copying from a <p> tag in this instance
-      input.innerHTML = document.getElementById(card).innerText;
+      input.textContent = document.getElementById(card).innerText;
       input.style.position = "fixed";
       document.body.appendChild(input);
       input.select();


### PR DESCRIPTION
Potential fix for [https://github.com/WLAN-Pi/wlanpi-webui/security/code-scanning/19](https://github.com/WLAN-Pi/wlanpi-webui/security/code-scanning/19)

In general, to fix “DOM text reinterpreted as HTML” issues you must avoid taking text from the DOM and assigning it to an HTML-interpretive sink such as `innerHTML`, `outerHTML`, jQuery’s `html()`, or similar. Instead, use text-only properties like `textContent` / `innerText`, or explicitly escape the text before assigning it to an HTML context.

For this specific function in `wlanpi_webui/templates/partials/network.html`, the safest and simplest fix that preserves behavior is:

- When creating the temporary `<textarea>`, set its textual content using `textContent` (or `value`) rather than `innerHTML`.
- Continue reading from `document.getElementById(card).innerText` (or optionally `textContent`) since the goal is to copy the visible text to the clipboard.

Concretely:

- In the `<script>` block at the top of the template, change line 10 from `input.innerHTML = document.getElementById(card).innerText;` to `input.textContent = document.getElementById(card).innerText;`. This avoids any HTML reinterpretation while leaving the user-visible functionality (copying text to clipboard) unchanged.
- No new methods, helpers, or imports are needed; this is a one-line change in the existing script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
