### PR TITLE
docs: replace CONTRIBUTING.md with delegation stub and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joshschmelzle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,75 +1,20 @@
-# Contribution Guidelines
+# Contributing
 
-To get the greatest chance of helpful responses, please observe the
-following additional notes.
+See the [WLAN Pi developer documentation](https://github.com/WLAN-Pi/developers) for contribution guidelines, workflow, branch naming, commit standards, and style guides.
 
-## Before You Start
-
-To increase the chances of Pull Request (PR) approval, first, talk to one of the core [WLAN Pi](https://github.com/WLAN-Pi/) [team members](https://github.com/orgs/WLAN-Pi/people).
-
-Aligning your ideas with the project team (before doing the work) will save everybody's time. 
-
-## Questions
-
-The GitHub issue tracker is for *bug reports* and *feature requests*. Please do
-not use it to ask questions about usage. These questions should
-instead be directed through other channels.
-
-## Good Bug Reports
-
-Please be aware of the following things when filing bug reports:
-
-1. Avoid raising duplicate issues. *Please* use the GitHub issue search feature
-   to check whether your bug report or feature request has been mentioned in
-   the past. Duplicate bug reports and feature requests are a huge maintenance
-   burden on the project maintainers. If it is clear from your report that you 
-   would have struggled to find the original, that's ok, but if searching for 
-   a selection of words in your issue title would have found the duplicate
-   then the issue will likely be closed.
-
-2. When filing bug reports about exceptions or tracebacks, please include the
-   *complete* traceback. Partial tracebacks, or just the exception text, are
-   not helpful. Issues that do not contain complete tracebacks may be closed
-   without warning.
-
-3. Make sure you provide a suitable amount of information to work with. This
-   means you should provide:
-
-   - Guidance on **how to reproduce the issue**. Ideally, this should be a
-     *small* code sample that can be run immediately by the maintainers.
-     Failing that, let us know what you're doing, how often it happens, what
-     environment you're using, etc. Be thorough: it prevents us needing to ask
-     further questions.
-   - Tell us **what you expected to happen**. When we run your example code,
-     what are we expecting to happen? What does "success" look like for your
-     code?
-   - Tell us **what actually happens**. It's not helpful for you to say "it
-     doesn't work" or "it fails". Tell us *how* it fails: do you get an
-     exception? How was the actual result different from your expected result?
-   - Tell us **what version you're using**, and
-     **how you installed it**. Different versions behave
-     differently and have different bugs.
-   
-   If you do not provide all of these things, it can take us much longer to
-   fix your problem. If we ask you to clarify these and you never respond, we
-   will close your issue without fixing it.
-
-### Development Environment
-
-Use whatever you want to develop. 
-
-Need help? Consider using PyCharm or Visual Studio Code with the official Python and Pylance extensions from Microsoft (recommended).
+## wlanpi-webui Specific
 
 ### Pull Requests
 
-Before submitting a PR perform the following:
+Before submitting a PR:
 
-1. Lint your code with `tox -e lint` and make sure it minimally passes the flake8 checks.
+1. Lint your code with `tox -e lint` and make sure it passes the flake8 checks.
+2. Format your code with `tox -e format` (runs autoflake, black, and isort).
+3. (Optional but encouraged) Create a test in `/tests` that validates your changes.
+4. (Optional but encouraged) Ensure tests pass by running `tox`.
 
-1. Format your code with `tox -e format` (this will run autoflake with desired options, black, and isort on the profiler codebase)
+Failure to lint and format will cause CI to fail and slow review.
 
-2. (Optional but encouraged) Create a test that validates your changes. this test should go in `/tests`.
+## Code of Conduct
 
-3. (Optional but encouraged) Ensure your tests pass by running `tox`.
-
-Failure to follow what is outlined in this document means it may take longer to test, validate, and merge your PR into the repo.
+See the [WLAN Pi Code of Conduct](https://github.com/WLAN-Pi/.github/blob/main/docs/code_of_conduct.md).


### PR DESCRIPTION
## Summary

Two changes:

1. **CONTRIBUTING.md** — replaces the full copy (which was duplicating and drifting from `WLAN-Pi/developers`) with a short delegation stub. Repo-specific content kept: the `tox` lint/format/test PR checklist and the CoC link (now pointing to the org `.github` CoC rather than a local file that didn't exist).

2. **CODEOWNERS** — adds `.github/CODEOWNERS` with `* @joshschmelzle` so PRs auto-request review.

Part of the docs consistency pass tracked in the WLAN-Pi documentation review.