### PR TITLE
Bump to 1.4.0-3 to publish trixie packages; verify packagecloud pushes

### DIFF
--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -41,25 +41,27 @@ jobs:
           name: wlanpi-webui-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}
 
-      - name: Upload armhf package to raspbian/${{ matrix.distro }}
-        if: matrix.arch == 'armhf'
-        uses: danielmundi/upload-packagecloud@main
-        with:
-          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
-          packagecloud-username: wlanpi
-          packagecloud-repo: dev
-          packagecloud-distrib: raspbian/${{ matrix.distro }}
-          packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
-
-      - name: Upload arm64 package to debian/${{ matrix.distro }}
-        if: matrix.arch == 'arm64'
-        uses: danielmundi/upload-packagecloud@main
-        with:
-          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
-          packagecloud-username: wlanpi
-          packagecloud-repo: dev
-          packagecloud-distrib: debian/${{ matrix.distro }}
-          packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      # Push with the package_cloud CLI directly instead of an action so upload
+      # errors are detected: the CLI exits 0 even when a push fails (Thor bug),
+      # which has produced green runs that uploaded nothing.
+      - name: Upload package to packagecloud ${{ matrix.distro }}
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          DEB_PACKAGE: ${{ steps.build-debian-package.outputs.deb-package }}
+        run: |
+          if [ -z "${DEB_PACKAGE}" ]; then
+            echo "::error::sbuild produced no .deb package"
+            exit 1
+          fi
+          case "${{ matrix.arch }}" in
+            armhf) target="wlanpi/dev/raspbian/${{ matrix.distro }}" ;;
+            *)     target="wlanpi/dev/debian/${{ matrix.distro }}" ;;
+          esac
+          sudo gem install package_cloud
+          echo "Pushing ${DEB_PACKAGE} to ${target}"
+          out=$(package_cloud push "${target}" "${DEB_PACKAGE}" 2>&1) || true
+          echo "${out}"
+          echo "${out}" | grep -q "success!"
 
   slack-workflow-status:
     if: always()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-webui (1.4.0-3) unstable; urgency=medium
+
+  * Rebuild to publish packages for Debian trixie to packagecloud
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Thu, 09 Jul 2026 23:26:39 -0400
+
 wlanpi-webui (1.4.0-2) unstable; urgency=medium
 
   * Add support for building on Debian trixie (Python 3.13)


### PR DESCRIPTION
Publishes a fresh bookworm + trixie build to packagecloud wlanpi/dev for the trixie image work, and hardens the pipeline:

- Changelog bump triggers the PR test build now and the packagecloud deploy on merge.
- The deploy's upload step now uses `package_cloud` directly and **verifies the push reports success**. The CLI exits 0 on errors (Thor bug), which has produced green deploy runs in several WLAN-Pi repos that uploaded nothing. It also fails when sbuild produces no `.deb`.
- `actions/checkout` / `actions/upload-artifact` bumped to v7 (Node 20 deprecation warnings).

After merge, confirm the package appears in https://packagecloud.io/wlanpi/dev/debian/dists/trixie/main/binary-arm64/Packages. With the verified push, a green run now actually means it landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
