### PR TITLE
Build for trixie only

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bookworm,trixie]
+        distro: [trixie]
         arch: [arm64]
     
 

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bookworm,trixie]
+        distro: [trixie]
         arch: [arm64]
 
     environment: PACKAGECLOUD


### PR DESCRIPTION
Restrict CI to Debian trixie only. The build matrix no longer includes bookworm, so deploys stop pushing non-trixie packages to packagecloud.

(Workflows only; no changelog change, so merging does not trigger a deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
