### PR TITLE
ci: do not post to Slack from fork PRs

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -39,7 +39,7 @@ jobs:
           path: ${{ steps.build-debian-package.outputs.deb-package }}
 
   slack-workflow-status:
-    if: always()
+    if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -64,7 +64,7 @@ jobs:
           echo "${out}" | grep -q "success!"
 
   slack-workflow-status:
-    if: always()
+    if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild


### PR DESCRIPTION
Guards the `slack-workflow-status` step so it does not run on fork-based PRs.

Fork PRs don't get repository secrets, so `SLACK_WEBHOOK_URL` is empty and the step fails with:

```
Error: Either slack_bot_token or slack_webhook_url is required.
```

Change: `if: always()` becomes

```yaml
if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
```

This still runs for push events and same-repo (org branch) PRs, which do have secrets, and skips only fork PRs. Matches the pattern already used across other WLAN-Pi repos (see WLAN-Pi/wlanpi-common#80 / #75).
