### PR TITLE
Remove shell=True from subprocess calls

### DIFF
--- a/wlanpi_webui/about/about.py
+++ b/wlanpi_webui/about/about.py
@@ -4,23 +4,25 @@ from flask import render_template, request
 
 from wlanpi_webui.about import bp
 from wlanpi_webui.config import Config, get_apt_package_version, get_hostname
-from wlanpi_webui.utils import is_htmx, system_service_running_state
+from wlanpi_webui.utils import is_htmx, run_pipeline, system_service_running_state
 
 
 @bp.route("/about")
 def about():
     try:
-        kernel_version = subprocess.check_output("uname -r", shell=True).decode()
+        kernel_version = subprocess.check_output(["uname", "-r"]).decode()
     except Exception:
         kernel_version = "unknown"
     try:
-        hardware_model = subprocess.check_output(
-            "cat /proc/cpuinfo | grep Model | cut -d ':' -f 2", shell=True
-        ).decode()
+        hardware_model = run_pipeline(
+            ["grep", "Model", "/proc/cpuinfo"],
+            ["cut", "-d", ":", "-f", "2"],
+        )
     except Exception:
         hardware_model = "unknown"
     try:
-        mode = subprocess.check_output("cat /etc/wlanpi-state", shell=True).decode()
+        with open("/etc/wlanpi-state") as state_file:
+            mode = state_file.read()
     except Exception:
         mode = "unknown"
     resp_data = {

--- a/wlanpi_webui/stream/stream.py
+++ b/wlanpi_webui/stream/stream.py
@@ -1,12 +1,11 @@
 # stats for homepage
 import socket
-import subprocess
 
 from flask import request
 from flask_minify import decorators as minify_decorators
 
 from wlanpi_webui.stream import bp
-from wlanpi_webui.utils import is_htmx
+from wlanpi_webui.utils import is_htmx, run_pipeline
 
 
 def get_stats():
@@ -25,9 +24,10 @@ def get_stats():
     ipStr = f"{IP}"
 
     # determine CPU load
-    cmd = r"top -bn1 | awk '/Cpu\(s\):/ {print $2 + $4}'"
     try:
-        CPU_USAGE = subprocess.check_output(cmd, shell=True).decode()
+        CPU_USAGE = run_pipeline(
+            ["top", "-bn1"], ["awk", r"/Cpu\(s\):/ {print $2 + $4}"]
+        )
         CPU = f"{float(CPU_USAGE):.0f}%"
         if float(CPU_USAGE) == 0:
             CPU = "0%"
@@ -37,16 +37,19 @@ def get_stats():
         CPU = "unknown"
 
     # determine mem useage
-    cmd = "free -m | awk 'NR==2{printf \"%s/%sMB %.0f%%\", $3,$2,$3*100/$2 }'"
     try:
-        MemUsage = subprocess.check_output(cmd, shell=True).decode()
+        MemUsage = run_pipeline(
+            ["free", "-m"],
+            ["awk", 'NR==2{printf "%s/%sMB %.0f%%", $3,$2,$3*100/$2 }'],
+        )
     except Exception:
         MemUsage = "unknown"
 
     # determine disk util
-    cmd = 'df -h | awk \'$NF=="/"{printf "%d/%dGB %s", $3,$2,$5}\''
     try:
-        Disk = subprocess.check_output(cmd, shell=True).decode()
+        Disk = run_pipeline(
+            ["df", "-h"], ["awk", '$NF=="/"{printf "%d/%dGB %s", $3,$2,$5}']
+        )
     except Exception:
         Disk = "unknown"
 
@@ -61,9 +64,15 @@ def get_stats():
     tempStr = "%sC" % str(round(tempI, 1))
 
     # determine uptime
-    cmd = r"uptime -p | sed -r 's/up|,//g' | sed -r 's/\s*week[s]?/w/g' | sed -r 's/\s*day[s]?/d/g' | sed -r 's/\s*hour[s]?/h/g' | sed -r 's/\s*minute[s]?/m/g'"
     try:
-        uptime = subprocess.check_output(cmd, shell=True).decode().strip()
+        uptime = run_pipeline(
+            ["uptime", "-p"],
+            ["sed", "-r", "s/up|,//g"],
+            ["sed", "-r", r"s/\s*week[s]?/w/g"],
+            ["sed", "-r", r"s/\s*day[s]?/d/g"],
+            ["sed", "-r", r"s/\s*hour[s]?/h/g"],
+            ["sed", "-r", r"s/\s*minute[s]?/m/g"],
+        ).strip()
     except Exception:
         uptime = "unknown"
 

--- a/wlanpi_webui/utils.py
+++ b/wlanpi_webui/utils.py
@@ -142,9 +142,9 @@ def system_service_exists(service):
     $ echo $?
     1
     """
-    cmd = f"/bin/systemctl list-unit-files {service}.*"
+    cmd = ["/bin/systemctl", "list-unit-files", f"{service}.*"]
     current_app.logger.info("subprocess is running %s", cmd)
-    result = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL)
+    result = subprocess.run(cmd, stdout=subprocess.DEVNULL)
     if result.returncode == 0:
         return True
     return False
@@ -157,10 +157,10 @@ def system_service_running_state(service):
     """
     try:
         # this cmd fails if service not installed
-        cmd = f"/bin/systemctl is-active --quiet {service}"
+        cmd = ["/bin/systemctl", "is-active", "--quiet", service]
         current_app.logger.info("subprocess is running %s", cmd)
         # check_returncode(): If returncode is non-zero, raise a CalledProcessError.
-        subprocess.run(cmd, shell=True).check_returncode()
+        subprocess.run(cmd).check_returncode()
     except subprocess.CalledProcessError as exc:
         current_app.logger.info(
             "service %s is not running (error code: %s)", service, exc.returncode
@@ -186,6 +186,34 @@ def run_command(cmd: list, suppress_output=False) -> str:
             return cp.stderr
 
     return "completed process return code is non-zero with no stdout or stderr"
+
+
+def run_pipeline(*commands, timeout: int = 10) -> str:
+    """Run piped commands without a shell and return decoded stdout.
+
+    Each argument is a command as a list, e.g.
+    ``run_pipeline(["top", "-bn1"], ["awk", "{print $1}"])`` is the
+    shell-free equivalent of ``top -bn1 | awk '{print $1}'``. Arguments are
+    passed to each program directly, so there is no shell interpolation and
+    no command injection is possible.
+    """
+    procs = []
+    prev_stdout = None
+    for command in commands:
+        proc = subprocess.Popen(
+            command,
+            stdin=prev_stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if prev_stdout is not None:
+            prev_stdout.close()  # let the upstream process receive SIGPIPE
+        prev_stdout = proc.stdout
+        procs.append(proc)
+    out, _ = procs[-1].communicate(timeout=timeout)
+    for proc in procs[:-1]:
+        proc.wait(timeout=timeout)
+    return out.decode()
 
 
 def systemd_service_message(service):


### PR DESCRIPTION
Removes every `shell=True` in the codebase. None of these commands take request/user input today, so there is no live injection, but `shell=True` is a footgun (any future dynamic input becomes an injection) and the shell pipelines are fragile.

## Changes

- **Simple commands** to argument lists: `["uname", "-r"]`, and the two `systemctl` calls in `utils.py` (`list-unit-files`, `is-active`). Byte-identical behavior; passing the pattern as a real arg is also more correct (no shell glob interference).
- **Shell pipelines** to a new `run_pipeline()` helper in `utils.py` that chains `subprocess.Popen` with `shell=False`, passing awk/sed scripts as literal args so nothing is shell-interpreted. Applied to CPU/mem/disk/uptime (`stream.py`) and the cpuinfo model lookup (`about.py`).
- **`cat` of a single file** replaced with `open().read()` (`/etc/wlanpi-state`), dropping a pointless subprocess.
- Removed the now-unused `subprocess` import from `stream.py`.

## Verification

Tested on a WLAN Pi (trixie, aarch64):

- `mem`, `disk`, `uptime`: output **byte-identical** old shell pipeline vs new `run_pipeline`.
- `cpu`: differs only by live-sample variance. `top -bn1 | awk ...` returns 4.3 / 6.1 / 6.5 on three consecutive runs on its own, so any two calls differ regardless of shell vs pipe. Same command semantics preserved.
- All three modules compile clean; no `shell=True` remains in the tree.