### PR TITLE
Show UIkit alert when starting a service that is not installed

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,3 +47,24 @@ class TestGetSafeRedirectTargetWithRequestContext:
     def test_different_origin_blocked(self):
         result = get_safe_redirect_target("http://evil.com/services")
         assert result == "/"
+
+
+from wlanpi_webui.utils import start_stop_service, service_not_installed_warning
+
+class TestServiceNotInstalled:
+    @patch("wlanpi_webui.utils.system_service_exists")
+    def test_start_uninstalled_service_returns_warning(self, mock_exists):
+        mock_exists.return_value = False
+        res = start_stop_service("start", "kismet")
+        assert "Kismet is not installed" in res
+        assert "UIkit.notification" in res
+
+    @patch("wlanpi_webui.utils.system_service_exists")
+    def test_start_uninstalled_grafana_returns_warning(self, mock_exists):
+        mock_exists.return_value = False
+        res = start_stop_service("start", "grafana-server")
+        assert "Grafana is not installed" in res
+
+    def test_service_not_installed_warning_formatting(self):
+        res = service_not_installed_warning("wlanpi-profiler")
+        assert "Profiler is not installed" in res

--- a/wlanpi_webui/grafana/grafana.py
+++ b/wlanpi_webui/grafana/grafana.py
@@ -269,7 +269,9 @@ def start_stop_grafana(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "grafana-server")
+            res = start_stop_service(task, "grafana-server")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -280,7 +282,9 @@ def start_stop_grafana_scanner0(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-scanner-wlan0")
+            res = start_stop_service(task, "wlanpi-grafana-scanner-wlan0")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -291,7 +295,9 @@ def start_stop_grafana_scanner1(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-scanner-wlan1")
+            res = start_stop_service(task, "wlanpi-grafana-scanner-wlan1")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -302,7 +308,9 @@ def start_stop_grafana_scanner2(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-scanner-wlan2")
+            res = start_stop_service(task, "wlanpi-grafana-scanner-wlan2")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -313,7 +321,9 @@ def start_stop_grafana_scat(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-scat")
+            res = start_stop_service(task, "wlanpi-grafana-scat")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -324,7 +334,9 @@ def start_stop_grafana_scat_pcap(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-scat-pcap")
+            res = start_stop_service(task, "wlanpi-grafana-scat-pcap")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -335,7 +347,9 @@ def start_stop_grafana_gps(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-gps")
+            res = start_stop_service(task, "wlanpi-grafana-gps")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -346,7 +360,9 @@ def start_stop_grafana_qscan(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-qscan")
+            res = start_stop_service(task, "wlanpi-grafana-qscan")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -357,7 +373,9 @@ def start_stop_grafana_internet(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-internet")
+            res = start_stop_service(task, "wlanpi-grafana-internet")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -368,7 +386,9 @@ def start_stop_grafana_health(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-health")
+            res = start_stop_service(task, "wlanpi-grafana-health")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -379,7 +399,9 @@ def start_stop_grafana_wipry24(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-wipry-lp-24")
+            res = start_stop_service(task, "wlanpi-grafana-wipry-lp-24")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -390,7 +412,9 @@ def start_stop_grafana_wipry5(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-wipry-lp-5")
+            res = start_stop_service(task, "wlanpi-grafana-wipry-lp-5")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -401,7 +425,9 @@ def start_stop_grafana_wipry6(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-wipry-lp-6")
+            res = start_stop_service(task, "wlanpi-grafana-wipry-lp-6")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -412,7 +438,9 @@ def start_stop_grafana_wispy24(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-wispy-24")
+            res = start_stop_service(task, "wlanpi-grafana-wispy-24")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204
@@ -423,7 +451,9 @@ def start_stop_grafana_wispy5(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-grafana-wispy-5")
+            res = start_stop_service(task, "wlanpi-grafana-wispy-5")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204

--- a/wlanpi_webui/kismet/kismet.py
+++ b/wlanpi_webui/kismet/kismet.py
@@ -21,7 +21,9 @@ def start_stop_kismet(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "kismet")
+            res = start_stop_service(task, "kismet")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204

--- a/wlanpi_webui/profiler/profiler.py
+++ b/wlanpi_webui/profiler/profiler.py
@@ -375,7 +375,9 @@ def start_stop_profiler(task):
     if is_htmx(request):
         core_status = system_service_running_state("wlanpi-core")
         if core_status:
-            start_stop_service(task, "wlanpi-profiler")
+            res = start_stop_service(task, "wlanpi-profiler")
+            if isinstance(res, str):
+                return res
         else:
             return wlanpi_core_warning
     return "", 204

--- a/wlanpi_webui/utils.py
+++ b/wlanpi_webui/utils.py
@@ -233,6 +233,9 @@ def start_stop_service(task, service):
     Starts or stops a service using wlanpi-core API.
     With HMAC authentication support.
     """
+    if task == "start" and not system_service_exists(service):
+        return service_not_installed_warning(service)
+
     params = {
         "name": f"{service}",
     }
@@ -328,3 +331,34 @@ def get_apt_package_version(package) -> str:
 
     _package_cache[package] = (version, current_time, current_mtime)
     return version
+
+
+def service_not_installed_warning(service_name):
+    friendly_name = service_name
+    # Clean up some common systemd service suffixes/prefixes for friendly display
+    if friendly_name.endswith(".service"):
+        friendly_name = friendly_name[:-8]
+    if friendly_name.startswith("wlanpi-grafana-"):
+        friendly_name = friendly_name.replace("wlanpi-grafana-", "Grafana ")
+        friendly_name = friendly_name.replace("-", " ").title()
+    elif friendly_name == "grafana-server":
+        friendly_name = "Grafana"
+    elif friendly_name == "wlanpi-profiler":
+        friendly_name = "Profiler"
+    elif friendly_name == "cockpit":
+        friendly_name = "Cockpit"
+    elif friendly_name == "kismet":
+        friendly_name = "Kismet"
+    else:
+        friendly_name = friendly_name.replace("-", " ").title()
+
+    return f"""
+<script>
+UIkit.notification({{
+    message: '<span uk-icon="icon: warning; ratio: 2"></span> {friendly_name} is not installed.',
+    status: 'warning',
+    pos: 'top-right',
+    timeout: 10000
+}});
+</script>
+"""


### PR DESCRIPTION
This PR adds validation to check if a systemd service unit exists before attempting to start it. If the service unit does not exist (meaning the package is not installed), the WebUI immediately returns a UIkit warning notification to notify the user. Closes #48.