### PR TITLE
Optimize LibreSpeed reverse proxy performance by enabling keepalive

### DIFF
--- a/install/etc/nginx/wlanpi_webui.conf
+++ b/install/etc/nginx/wlanpi_webui.conf
@@ -5,6 +5,7 @@ map $http_upgrade $connection_upgrade {
 
 upstream librespeed {
     server 127.0.0.1:8081;
+    keepalive 32;
 }
 
 upstream grafana {
@@ -51,6 +52,8 @@ server {
     }
 
     location /app/librespeed/  {
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
This PR optimizes the LibreSpeed reverse proxy performance by configuring a keepalive connection pool to the upstream server and enabling HTTP/1.1 with cleared Connection headers. This prevents the connection establishment overhead (TCP socket setup and teardown on every speed test request/chunk) which was causing significant performance degradation through the reverse proxy. Closes #43.