### PR TITLE
Release wlanpi-webui 1.4.0-4 for Debian trixie

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+wlanpi-webui (1.4.0-4) unstable; urgency=medium
+
+  * Remove shell=True from subprocess calls (harden against shell injection).
+  * Regenerate dependency locks, fix security alerts, and drop flask-minify.
+  * Upgrade UIKit 3.16.26 -> 3.25.20.
+  * Show a UIkit alert when starting a service that is not installed
+    (closes #48).
+  * Optimize LibreSpeed reverse proxy performance by enabling keepalive.
+  * Build for Debian trixie only and publish to packagecloud.
+  * CI: do not post to Slack from fork PRs (secrets are unavailable there).
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Wed, 15 Jul 2026 03:24:02 -0400
+
 wlanpi-webui (1.4.0-3) unstable; urgency=medium
 
   * Rebuild to publish packages for Debian trixie to packagecloud


### PR DESCRIPTION
Bumps `debian/changelog` (`1.4.0-3` -> `1.4.0-4`) to publish the work merged since the last release as a trixie build. None of it had been published (deploy only fires on `debian/changelog` changes).

Included since 1.4.0-3:
- Remove `shell=True` from subprocess calls (#87)
- Regenerate dependency locks, fix security alerts, drop flask-minify (#88)
- Upgrade UIKit 3.16.26 -> 3.25.20 (#89)
- Service-not-installed UIkit alert (#90, closes #48)
- LibreSpeed reverse-proxy keepalive (#91)
- Build for trixie only (#85); no Slack from fork PRs (#86)